### PR TITLE
feat: add card detection and pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,36 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - run: npm ci
+      - run: BASE_URL=/safeDNI/ npm run build
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@ npm test
 npm run typecheck
 ```
 
+## Deployment
+This project includes a GitHub Actions workflow to build and publish the app to **GitHub Pages**. Enable Pages in your repository settings and each push to `main` will update the site at:
+
+```
+https://<your-username>.github.io/safeDNI/
+```
+
 ## Privacy
 - No uploads, no analytics, no network calls (except local assets).
 - Service worker blocks cross-origin fetch by default.

--- a/src/lib/detection.ts
+++ b/src/lib/detection.ts
@@ -4,20 +4,85 @@ import { orderCorners, expandQuad } from './geometry';
 
 /**
  * Attempt to detect card corners using OpenCV.js.
- * Placeholder implementation currently returns null.
  */
-export async function detectCardCorners(_mat: any): Promise<{ pts: Point[] } | null> {
-  await cvReady();
-  // TODO: implement detection pipeline
-  return null;
+export async function detectCardCorners(mat: any): Promise<{ pts: Point[] } | null> {
+  const cv = await cvReady();
+  const gray = new cv.Mat();
+  cv.cvtColor(mat, gray, cv.COLOR_RGBA2GRAY);
+  const blurred = new cv.Mat();
+  cv.GaussianBlur(gray, blurred, new cv.Size(5, 5), 0);
+  const edges = new cv.Mat();
+  cv.Canny(blurred, edges, 50, 150);
+
+  const contours = new cv.MatVector();
+  const hierarchy = new cv.Mat();
+  cv.findContours(edges, contours, hierarchy, cv.RETR_EXTERNAL, cv.CHAIN_APPROX_SIMPLE);
+
+  let best: Point[] | null = null;
+  let maxArea = 0;
+  for (let i = 0; i < contours.size(); i++) {
+    const cnt = contours.get(i);
+    const peri = cv.arcLength(cnt, true);
+    const approx = new cv.Mat();
+    cv.approxPolyDP(cnt, approx, 0.02 * peri, true);
+    if (approx.rows === 4) {
+      const area = cv.contourArea(approx);
+      if (area > maxArea) {
+        maxArea = area;
+        const pts: Point[] = [];
+        for (let j = 0; j < approx.data32S.length; j += 2) {
+          pts.push({ x: approx.data32S[j], y: approx.data32S[j + 1] });
+        }
+        best = pts;
+      }
+    }
+    cnt.delete();
+    approx.delete();
+  }
+
+  edges.delete();
+  blurred.delete();
+  gray.delete();
+  contours.delete();
+  hierarchy.delete();
+
+  if (!best) return null;
+  return { pts: orderCorners(best) };
 }
 
 /**
  * Warp the source image to a normalized card rectangle.
- * This is a placeholder returning null.
  */
-export async function warpToCard(_mat: any, _pts: Point[], _heightPx = 1000, _aspect = 85.6 / 53.98, _marginPct = 0.02): Promise<any> {
-  await cvReady();
-  // TODO: implement perspective transform
-  return null;
+export async function warpToCard(
+  mat: any,
+  pts: Point[],
+  heightPx = 1000,
+  aspect = 85.6 / 53.98,
+  marginPct = 0.02,
+): Promise<any> {
+  const cv = await cvReady();
+  const widthPx = Math.round(heightPx * aspect);
+  const expanded = expandQuad(pts, marginPct);
+  const ordered = orderCorners(expanded);
+
+  const srcTri = cv.matFromArray(4, 1, cv.CV_32FC2, ordered.flatMap(p => [p.x, p.y]));
+  const dstTri = cv.matFromArray(4, 1, cv.CV_32FC2, [
+    0,
+    0,
+    widthPx,
+    0,
+    widthPx,
+    heightPx,
+    0,
+    heightPx,
+  ]);
+  const M = cv.getPerspectiveTransform(srcTri, dstTri);
+  const dst = new cv.Mat();
+  cv.warpPerspective(mat, dst, M, new cv.Size(widthPx, heightPx), cv.INTER_LINEAR, cv.BORDER_REPLICATE);
+
+  srcTri.delete();
+  dstTri.delete();
+  M.delete();
+
+  return dst;
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,5 +2,6 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
 export default defineConfig({
+  base: process.env.BASE_URL || '/',
   plugins: [react()],
 })


### PR DESCRIPTION
## Summary
- implement OpenCV-based card corner detection and warping helpers
- configure Vite for GitHub Pages and document deployment
- add workflow to build and deploy to GitHub Pages

## Testing
- `npm test -- --run`
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689c4a4df2ac832e843f2e01a7879121