### PR TITLE
Implement basic DNI redaction workflow and GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,36 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run build
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4
+

--- a/src/components/CardDropzone.tsx
+++ b/src/components/CardDropzone.tsx
@@ -1,9 +1,83 @@
-import React from 'react';
+import React, { useCallback } from 'react';
+import { useAppStore } from '../state/store';
+import { detectCardCorners, warpToCard } from '../lib/detection';
+import { cvReady } from '../lib/opencv';
 
-export default function CardDropzone() {
+async function processFile(file: File): Promise<string> {
+  const dataUrl = await new Promise<string>((resolve) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as string);
+    reader.readAsDataURL(file);
+  });
+
+  const img = new Image();
+  img.src = dataUrl;
+
+  await new Promise((res) => (img.onload = res));
+
+  const canvas = document.createElement('canvas');
+  canvas.width = img.width;
+  canvas.height = img.height;
+  const ctx = canvas.getContext('2d')!;
+  ctx.drawImage(img, 0, 0);
+
+  const cv = await cvReady();
+  const mat = cv.imread(canvas);
+  let warped = mat;
+  try {
+    const detected = await detectCardCorners(mat);
+    if (detected) {
+      warped = await warpToCard(mat, detected.pts);
+    }
+  } catch {
+    // ignore detection errors, fall back to original image
+  }
+  const outCanvas = document.createElement('canvas');
+  cv.imshow(outCanvas, warped);
+
+  mat.delete();
+  if (warped !== mat) warped.delete();
+
+  return outCanvas.toDataURL('image/png');
+}
+
+interface Props {
+  side?: 'front' | 'back';
+}
+
+export default function CardDropzone({ side = 'front' }: Props) {
+  const setImage = useAppStore((s) => (side === 'front' ? s.setFront : s.setBack));
+
+  const handleFiles = useCallback(
+    async (files: FileList | null) => {
+      if (!files?.length) return;
+      const dataUrl = await processFile(files[0]);
+      setImage(dataUrl);
+    },
+    [setImage],
+  );
+
+  const onDrop = useCallback(
+    (e: React.DragEvent<HTMLDivElement>) => {
+      e.preventDefault();
+      handleFiles(e.dataTransfer.files);
+    },
+    [handleFiles],
+  );
+
+  const onChange = (e: React.ChangeEvent<HTMLInputElement>) => handleFiles(e.target.files);
+
   return (
-    <div className="flex h-40 w-full items-center justify-center rounded border-2 border-dashed border-gray-400 text-gray-500">
-      Drop DNI image here
+    <div
+      onDragOver={(e) => e.preventDefault()}
+      onDrop={onDrop}
+      className="flex h-40 w-full cursor-pointer items-center justify-center rounded border-2 border-dashed border-gray-400 text-gray-500"
+    >
+      <label className="flex h-full w-full items-center justify-center">
+        <span>Drop DNI image here or click to select</span>
+        <input type="file" accept="image/*" className="hidden" onChange={onChange} />
+      </label>
     </div>
   );
 }
+

--- a/src/components/ExportPanel.tsx
+++ b/src/components/ExportPanel.tsx
@@ -1,10 +1,49 @@
 import React from 'react';
+import { saveAs } from 'file-saver';
+import { exportPNG } from '../lib/export';
+import type { FieldRegion } from '../types';
 
-export default function ExportPanel() {
+interface Props {
+  image: string;
+  fieldMap: FieldRegion[];
+  masked: Record<string, { opacity?: number }>;
+}
+
+export default function ExportPanel({ image, fieldMap, masked }: Props) {
+  const handleExport = async () => {
+    const img = new Image();
+    img.src = image;
+    await new Promise((res) => (img.onload = res));
+
+    const canvas = document.createElement('canvas');
+    canvas.width = img.width;
+    canvas.height = img.height;
+    const ctx = canvas.getContext('2d')!;
+    ctx.drawImage(img, 0, 0);
+
+    fieldMap
+      .filter((f) => masked[f.id])
+      .forEach((f) => {
+        const pts = f.polygon.map((p) => ({ x: p.x * canvas.width, y: p.y * canvas.height }));
+        ctx.fillStyle = 'black';
+        ctx.globalAlpha = masked[f.id].opacity ?? 0.9;
+        ctx.beginPath();
+        ctx.moveTo(pts[0].x, pts[0].y);
+        for (let i = 1; i < pts.length; i++) ctx.lineTo(pts[i].x, pts[i].y);
+        ctx.closePath();
+        ctx.fill();
+      });
+
+    const blob = await exportPNG(canvas);
+    saveAs(blob, 'dni.png');
+  };
+
   return (
     <div className="rounded border p-4">
       <h2 className="mb-2 font-semibold">Export</h2>
-      <button className="rounded bg-green-600 px-4 py-2 text-white">Download PNG</button>
+      <button className="rounded bg-green-600 px-4 py-2 text-white" onClick={handleExport}>
+        Download PNG
+      </button>
     </div>
   );
 }

--- a/src/components/PresetPicker.tsx
+++ b/src/components/PresetPicker.tsx
@@ -1,10 +1,20 @@
 import React from 'react';
 import { PRESETS } from '../lib/redactions';
 
-export default function PresetPicker() {
+interface Props {
+  onSelect: (id: string) => void;
+}
+
+export default function PresetPicker({ onSelect }: Props) {
   return (
-    <select className="rounded border p-2">
-      <option value="">Choose preset</option>
+    <select
+      className="rounded border p-2"
+      onChange={(e) => onSelect(e.target.value)}
+      defaultValue=""
+    >
+      <option value="" disabled>
+        Choose preset
+      </option>
       {PRESETS.map((p) => (
         <option key={p.id} value={p.id}>
           {p.name}

--- a/src/components/RedactionOverlay.tsx
+++ b/src/components/RedactionOverlay.tsx
@@ -1,5 +1,32 @@
 import React from 'react';
+import type { FieldRegion } from '../types';
 
-export default function RedactionOverlay() {
-  return <div className="absolute inset-0 pointer-events-none">Redactions go here</div>;
+interface Props {
+  fieldMap: FieldRegion[];
+  masked: Record<string, { opacity?: number }>;
+  width: number;
+  height: number;
 }
+
+export default function RedactionOverlay({ fieldMap, masked, width, height }: Props) {
+  return (
+    <svg
+      className="pointer-events-none absolute inset-0"
+      width={width}
+      height={height}
+      viewBox={`0 0 ${width} ${height}`}
+    >
+      {fieldMap
+        .filter((f) => masked[f.id])
+        .map((f) => (
+          <polygon
+            key={f.id}
+            points={f.polygon.map((p) => `${p.x * width},${p.y * height}`).join(' ')}
+            fill="black"
+            opacity={masked[f.id].opacity ?? 0.9}
+          />
+        ))}
+    </svg>
+  );
+}
+

--- a/src/lib/detection.ts
+++ b/src/lib/detection.ts
@@ -4,20 +4,88 @@ import { orderCorners, expandQuad } from './geometry';
 
 /**
  * Attempt to detect card corners using OpenCV.js.
- * Placeholder implementation currently returns null.
+ * Returns ordered points or null if detection fails.
  */
-export async function detectCardCorners(_mat: any): Promise<{ pts: Point[] } | null> {
-  await cvReady();
-  // TODO: implement detection pipeline
-  return null;
+export async function detectCardCorners(mat: any): Promise<{ pts: Point[] } | null> {
+  const cv = await cvReady();
+
+  const gray = new cv.Mat();
+  cv.cvtColor(mat, gray, cv.COLOR_RGBA2GRAY, 0);
+  const blurred = new cv.Mat();
+  cv.GaussianBlur(gray, blurred, new cv.Size(5, 5), 0);
+  const edges = new cv.Mat();
+  cv.Canny(blurred, edges, 50, 150);
+
+  const contours = new cv.MatVector();
+  const hierarchy = new cv.Mat();
+  cv.findContours(edges, contours, hierarchy, cv.RETR_EXTERNAL, cv.CHAIN_APPROX_SIMPLE);
+
+  let best: Point[] | null = null;
+  let bestArea = 0;
+  for (let i = 0; i < contours.size(); i++) {
+    const cnt = contours.get(i);
+    const peri = cv.arcLength(cnt, true);
+    const approx = new cv.Mat();
+    cv.approxPolyDP(cnt, approx, 0.02 * peri, true);
+    if (approx.rows === 4) {
+      const area = cv.contourArea(approx);
+      if (area > bestArea) {
+        bestArea = area;
+        const pts: Point[] = [];
+        const data = approx.data32S;
+        for (let j = 0; j < data.length; j += 2) {
+          pts.push({ x: data[j], y: data[j + 1] });
+        }
+        best = pts;
+      }
+    }
+    cnt.delete();
+    approx.delete();
+  }
+
+  gray.delete();
+  blurred.delete();
+  edges.delete();
+  contours.delete();
+  hierarchy.delete();
+
+  if (!best) return null;
+  return { pts: orderCorners(best) };
 }
 
 /**
  * Warp the source image to a normalized card rectangle.
- * This is a placeholder returning null.
  */
-export async function warpToCard(_mat: any, _pts: Point[], _heightPx = 1000, _aspect = 85.6 / 53.98, _marginPct = 0.02): Promise<any> {
-  await cvReady();
-  // TODO: implement perspective transform
-  return null;
+export async function warpToCard(
+  mat: any,
+  pts: Point[],
+  heightPx = 1000,
+  aspect = 85.6 / 53.98,
+  marginPct = 0.02,
+): Promise<any> {
+  const cv = await cvReady();
+  const expanded = expandQuad(pts, marginPct);
+  const widthPx = Math.round(heightPx * aspect);
+
+  const srcPts = cv.matFromArray(4, 1, cv.CV_32FC2, [
+    expanded[0].x,
+    expanded[0].y,
+    expanded[1].x,
+    expanded[1].y,
+    expanded[2].x,
+    expanded[2].y,
+    expanded[3].x,
+    expanded[3].y,
+  ]);
+  const dstPts = cv.matFromArray(4, 1, cv.CV_32FC2, [0, 0, widthPx, 0, widthPx, heightPx, 0, heightPx]);
+  const M = cv.getPerspectiveTransform(srcPts, dstPts);
+  const dst = new cv.Mat();
+  const size = new cv.Size(widthPx, heightPx);
+  cv.warpPerspective(mat, dst, M, size, cv.INTER_LINEAR, cv.BORDER_REPLICATE, new cv.Scalar());
+
+  srcPts.delete();
+  dstPts.delete();
+  M.delete();
+
+  return dst;
 }

--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -1,10 +1,52 @@
-import React from 'react';
+import React, { useRef, useState, useEffect } from 'react';
+import CardDropzone from '../components/CardDropzone';
+import PresetPicker from '../components/PresetPicker';
+import RedactionOverlay from '../components/RedactionOverlay';
+import ExportPanel from '../components/ExportPanel';
+import { FIELD_MAP_FRONT, PRESETS } from '../lib/redactions';
+import { useAppStore } from '../state/store';
 
 export default function App() {
+  const frontImage = useAppStore((s) => s.frontImage);
+  const imgRef = useRef<HTMLImageElement>(null);
+  const [size, setSize] = useState({ w: 0, h: 0 });
+  const [masked, setMasked] = useState<Record<string, { opacity?: number }>>({});
+
+  useEffect(() => {
+    if (frontImage && imgRef.current) {
+      const img = imgRef.current;
+      const update = () => setSize({ w: img.naturalWidth, h: img.naturalHeight });
+      if (img.complete) update();
+      else img.onload = update;
+    }
+  }, [frontImage]);
+
+  const handlePreset = (id: string) => {
+    const preset = PRESETS.find((p) => p.id === id);
+    if (!preset) return;
+    const m: Record<string, { opacity?: number }> = {};
+    preset.fields.forEach((f) => {
+      m[f] = { opacity: preset.defaults?.opacity };
+    });
+    setMasked(m);
+  };
+
   return (
-    <main className="min-h-screen p-4 text-center text-gray-800 dark:text-gray-100">
-      <h1 className="text-3xl font-bold">SafeDNI</h1>
-      <p className="mt-4">Offline DNI redaction tool (skeleton).</p>
+    <main className="min-h-screen p-4 text-gray-800 dark:text-gray-100">
+      <h1 className="mb-4 text-center text-3xl font-bold">SafeDNI</h1>
+      <div className="mx-auto max-w-xl space-y-4">
+        <CardDropzone />
+        {frontImage && (
+          <div className="relative inline-block">
+            <img ref={imgRef} src={frontImage} alt="DNI" className="max-w-full" />
+            <RedactionOverlay fieldMap={FIELD_MAP_FRONT} masked={masked} width={size.w} height={size.h} />
+          </div>
+        )}
+        <div className="flex gap-2">
+          <PresetPicker onSelect={handlePreset} />
+        </div>
+        {frontImage && <ExportPanel image={frontImage} fieldMap={FIELD_MAP_FRONT} masked={masked} />}
+      </div>
     </main>
   );
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,7 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
 
-export default defineConfig({
+export default defineConfig(({ mode }) => ({
   plugins: [react()],
-})
+  base: process.env.GITHUB_ACTIONS ? '/safeDNI/' : '/',
+}));


### PR DESCRIPTION
## Summary
- allow dropping a DNI image, auto-detecting and warping the card with OpenCV
- overlay preset-driven redactions and export sanitized PNGs
- configure Vite for Pages and add deployment workflow

## Testing
- `npx vitest run`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689c4a4df2ac832e843f2e01a7879121