### PR TITLE
chore: add non-watch test script and instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,4 @@
+# Repository Guide
+
+- Run tests with `npm test` before committing changes.
+- The test script runs Vitest in non-watch mode and clears proxy-related npm environment variables.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",
-    "test": "vitest"
+    "test": "node scripts/run-tests.mjs"
   },
   "dependencies": {
     "file-saver": "^2.0.5"

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+import { spawn } from 'child_process';
+
+// Remove proxy-related npm config env vars to avoid warnings
+delete process.env.npm_config_http_proxy;
+delete process.env.npm_config_https_proxy;
+
+const child = spawn('npx', ['vitest', 'run'], {
+  stdio: 'inherit',
+  env: process.env,
+});
+
+child.on('close', (code) => process.exit(code));


### PR DESCRIPTION
## Summary
- run Vitest in non-watch mode via a helper script that clears proxy env vars
- document repository testing instructions in `AGENTS.md`

## Testing
- `npm test >/tmp/test.log && tail -n 20 /tmp/test.log`
- `node scripts/run-tests.mjs >/tmp/test.log && tail -n 20 /tmp/test.log`


------
https://chatgpt.com/codex/tasks/task_e_689ca3677fc8832ead5f29487abbfe7c