### PR TITLE
feat: add basic card detection and cropping

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,4 @@
+# Repository Guide
+
+- Run tests with `npm test` before committing changes.
+- The test script runs Vitest in non-watch mode and clears proxy-related npm environment variables.

--- a/index.html
+++ b/index.html
@@ -11,8 +11,13 @@
       <h1 class="mb-4 text-center text-3xl font-bold">SafeDNI</h1>
       <div class="mx-auto max-w-xl space-y-4">
         <input id="front-input" type="file" accept="image/*" class="block w-full" />
-        <img id="front-preview" alt="DNI preview" class="hidden max-w-full" />
-        <button id="save-front" class="px-4 py-2 text-white bg-blue-600 rounded">Download</button>
+        <canvas id="card-canvas" class="hidden max-w-full"></canvas>
+        <div id="controls" class="hidden space-y-2">
+          <label class="block text-sm">Margin
+            <input id="margin" type="range" min="0" max="0.1" step="0.005" value="0.02" class="w-full" />
+          </label>
+          <button id="save-front" class="px-4 py-2 text-white bg-blue-600 rounded">Download</button>
+        </div>
       </div>
     </main>
     <script type="module" src="/src/main.ts"></script>

--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
       <h1 class="mb-4 text-center text-3xl font-bold">SafeDNI</h1>
       <div class="mx-auto max-w-xl space-y-4">
         <input id="front-input" type="file" accept="image/*" class="block w-full" />
+        <canvas id="source-canvas" class="hidden max-w-full"></canvas>
         <canvas id="card-canvas" class="hidden max-w-full"></canvas>
         <div id="controls" class="hidden space-y-2">
           <label class="block text-sm">Margin

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",
-    "test": "vitest"
+    "test": "node scripts/run-tests.mjs"
   },
   "dependencies": {
     "file-saver": "^2.0.5"

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+import { spawn } from 'child_process';
+
+// Remove proxy-related npm config env vars to avoid warnings
+delete process.env.npm_config_http_proxy;
+delete process.env.npm_config_https_proxy;
+
+const child = spawn('npx', ['vitest', 'run'], {
+  stdio: 'inherit',
+  env: process.env,
+});
+
+child.on('close', (code) => process.exit(code));

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,6 +13,7 @@ if ('serviceWorker' in navigator) {
 }
 
 const frontInput = document.getElementById('front-input') as HTMLInputElement | null;
+const sourceCanvas = document.getElementById('source-canvas') as HTMLCanvasElement | null;
 const cardCanvas = document.getElementById('card-canvas') as HTMLCanvasElement | null;
 const marginInput = document.getElementById('margin') as HTMLInputElement | null;
 const controls = document.getElementById('controls');
@@ -20,6 +21,7 @@ const saveFront = document.getElementById('save-front') as HTMLButtonElement | n
 
 let originalMat: any | null = null;
 let detectedPts: Point[] | null = null;
+let dragIndex: number | null = null;
 
 async function renderWarp() {
   if (!originalMat || !detectedPts || !cardCanvas || !marginInput) return;
@@ -33,23 +35,48 @@ async function renderWarp() {
   warped.delete();
 }
 
+async function drawOverlay() {
+  if (!sourceCanvas || !originalMat || !detectedPts) return;
+  const cv = await cvReady();
+  cv.imshow(sourceCanvas, originalMat);
+  const ctx = sourceCanvas.getContext('2d');
+  if (!ctx) return;
+  ctx.strokeStyle = 'lime';
+  ctx.lineWidth = 2;
+  ctx.fillStyle = 'rgba(0,255,0,0.4)';
+  ctx.beginPath();
+  detectedPts.forEach((p, i) => {
+    if (i === 0) ctx.moveTo(p.x, p.y);
+    else ctx.lineTo(p.x, p.y);
+  });
+  ctx.closePath();
+  ctx.stroke();
+  detectedPts.forEach((p) => {
+    ctx.beginPath();
+    ctx.arc(p.x, p.y, 6, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.stroke();
+  });
+  sourceCanvas.classList.remove('hidden');
+}
+
 frontInput?.addEventListener('change', () => {
   const file = frontInput.files?.[0];
-  if (!file) return;
+  if (!file || !sourceCanvas) return;
   const img = new Image();
   img.onload = async () => {
-    const canvas = document.createElement('canvas');
-    canvas.width = img.width;
-    canvas.height = img.height;
-    const ctx = canvas.getContext('2d');
+    sourceCanvas.width = img.width;
+    sourceCanvas.height = img.height;
+    const ctx = sourceCanvas.getContext('2d');
     if (!ctx) return;
     ctx.drawImage(img, 0, 0);
     const cv = await cvReady();
     if (originalMat) originalMat.delete();
-    originalMat = cv.imread(canvas);
+    originalMat = cv.imread(sourceCanvas);
     const result = await detectCardCorners(originalMat);
     if (result) {
       detectedPts = result.pts;
+      await drawOverlay();
       await renderWarp();
       controls?.classList.remove('hidden');
     }
@@ -59,6 +86,37 @@ frontInput?.addEventListener('change', () => {
 
 marginInput?.addEventListener('input', () => {
   renderWarp();
+});
+
+sourceCanvas?.addEventListener('mousedown', (e) => {
+  if (!detectedPts) return;
+  const rect = sourceCanvas.getBoundingClientRect();
+  const scaleX = sourceCanvas.width / rect.width;
+  const scaleY = sourceCanvas.height / rect.height;
+  const x = (e.clientX - rect.left) * scaleX;
+  const y = (e.clientY - rect.top) * scaleY;
+  detectedPts.forEach((p, i) => {
+    if (Math.hypot(p.x - x, p.y - y) < 10) {
+      dragIndex = i;
+    }
+  });
+});
+
+window.addEventListener('mousemove', (e) => {
+  if (dragIndex === null || !detectedPts || !sourceCanvas) return;
+  const rect = sourceCanvas.getBoundingClientRect();
+  const scaleX = sourceCanvas.width / rect.width;
+  const scaleY = sourceCanvas.height / rect.height;
+  detectedPts[dragIndex] = {
+    x: (e.clientX - rect.left) * scaleX,
+    y: (e.clientY - rect.top) * scaleY,
+  };
+  void drawOverlay();
+  void renderWarp();
+});
+
+window.addEventListener('mouseup', () => {
+  dragIndex = null;
 });
 
 saveFront?.addEventListener('click', () => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,8 @@
 import { saveAs } from 'file-saver';
 import './index.css';
+import type { Point } from './types';
+import { detectCardCorners, warpToCard } from './lib/detection';
+import { cvReady } from './lib/opencv';
 
 if ('serviceWorker' in navigator) {
   window.addEventListener('load', () => {
@@ -10,21 +13,57 @@ if ('serviceWorker' in navigator) {
 }
 
 const frontInput = document.getElementById('front-input') as HTMLInputElement | null;
-const frontPreview = document.getElementById('front-preview') as HTMLImageElement | null;
-const saveFront = document.getElementById('save-front');
+const cardCanvas = document.getElementById('card-canvas') as HTMLCanvasElement | null;
+const marginInput = document.getElementById('margin') as HTMLInputElement | null;
+const controls = document.getElementById('controls');
+const saveFront = document.getElementById('save-front') as HTMLButtonElement | null;
+
+let originalMat: any | null = null;
+let detectedPts: Point[] | null = null;
+
+async function renderWarp() {
+  if (!originalMat || !detectedPts || !cardCanvas || !marginInput) return;
+  const margin = Number(marginInput.value);
+  const warped = await warpToCard(originalMat, detectedPts, 1000, 85.6 / 53.98, margin);
+  cardCanvas.width = warped.cols;
+  cardCanvas.height = warped.rows;
+  const cv = await cvReady();
+  cv.imshow(cardCanvas, warped);
+  cardCanvas.classList.remove('hidden');
+  warped.delete();
+}
 
 frontInput?.addEventListener('change', () => {
   const file = frontInput.files?.[0];
-  if (file && frontPreview) {
-    frontPreview.src = URL.createObjectURL(file);
-    frontPreview.classList.remove('hidden');
-  }
+  if (!file) return;
+  const img = new Image();
+  img.onload = async () => {
+    const canvas = document.createElement('canvas');
+    canvas.width = img.width;
+    canvas.height = img.height;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    ctx.drawImage(img, 0, 0);
+    const cv = await cvReady();
+    if (originalMat) originalMat.delete();
+    originalMat = cv.imread(canvas);
+    const result = await detectCardCorners(originalMat);
+    if (result) {
+      detectedPts = result.pts;
+      await renderWarp();
+      controls?.classList.remove('hidden');
+    }
+  };
+  img.src = URL.createObjectURL(file);
+});
+
+marginInput?.addEventListener('input', () => {
+  renderWarp();
 });
 
 saveFront?.addEventListener('click', () => {
-  if (frontPreview?.src) {
-    fetch(frontPreview.src)
-      .then(res => res.blob())
-      .then(blob => saveAs(blob, 'dni-front.png'));
-  }
+  if (!cardCanvas) return;
+  cardCanvas.toBlob((blob) => {
+    if (blob) saveAs(blob, 'dni-front.png');
+  });
 });


### PR DESCRIPTION
## Summary
- add canvas-based preview with adjustable margin
- detect card corners with OpenCV and warp to ID aspect

## Testing
- `npm test >/tmp/test.log && tail -n 20 /tmp/test.log`
- `npm run typecheck >/tmp/type.log && tail -n 20 /tmp/type.log`


------
https://chatgpt.com/codex/tasks/task_e_689ca3677fc8832ead5f29487abbfe7c